### PR TITLE
ci: 每次 push 自动部署 scripts/templates 到自建服务器

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy scripts to server
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'scripts/**'
+      - 'templates/**'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+
+      - name: Deploy scripts & templates via rsync
+        run: |
+          rsync -az --delete \
+            -e "ssh -i ~/.ssh/id_deploy -o StrictHostKeyChecking=accept-new" \
+            scripts templates \
+            "${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }}:/home/deploy/substore-scripts/"


### PR DESCRIPTION
让 Sub-Store 从自建服务器本机读取脚本/模板,不再依赖 GitHub 代理/Gitee 等第三方。依赖 Secrets: DEPLOY_KEY / SERVER_HOST / SERVER_USER(已配)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)